### PR TITLE
Bump better-auth catalog to 1.6.26

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,7 +39,9 @@ catalogs:
     "@astrojs/partytown": ^2.1.7
     "@astrojs/react": ^5.0.4
     "@astrojs/sitemap": ^3.7.2
-    "@better-auth/passkey": ^1.6.9
+    "@better-auth/passkey": ^1.6.26
+    "@better-auth/oauth-provider": ^1.6.26
+    "@better-auth/react": ^1.6.26
     "@fontsource-variable/bricolage-grotesque": ^5.2.10
     "@fontsource-variable/inter": ^5.2.8
     "@tailwindcss/typography": ^0.5.19
@@ -53,7 +55,7 @@ catalogs:
     "@tanstack/react-start": ^1.167.43
     "@tanstack/react-virtual": ^3.13.24
     "@unpic/react": ^1.0.2
-    better-auth: ^1.6.9
+    better-auth: ^1.6.26
     daisyui: ^5.5.19
     drizzle-orm: ^0.45.2
     drizzle-seed: ^0.3.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* __->__ #306

Bump better-auth and @better-auth/passkey from 1.6.9 to 1.6.26, and add
@better-auth/oauth-provider and @better-auth/react to the runtime catalog.

Needed for the accounts identity provider (oauth-provider plugin + react
client) and keeps all better-auth packages on one version.

Design: .hermes/plans/2026-08-09_043459-accounts-central-idp.md (Task 1)
Related: accounts central IdP initiative