### PR TITLE
Add accounts build config and Wrangler bindings

### DIFF
--- a/apps/accounts/eslint.config.ts
+++ b/apps/accounts/eslint.config.ts
@@ -1,0 +1,36 @@
+import antfu from "@antfu/eslint-config";
+import pluginQuery from "@tanstack/eslint-plugin-query";
+import pluginRouter from "@tanstack/eslint-plugin-router";
+
+export default antfu(
+  {
+    formatters: true,
+    jsx: {
+      a11y: true,
+    },
+    react: {
+      reactCompiler: true,
+    },
+  },
+  {
+    ignores: [
+      "dist/**",
+      ".wrangler/**",
+      ".tanstack/**",
+    ],
+  },
+  {
+    files: ["**/routeTree.gen.ts"],
+    rules: {
+      "eslint-comments/no-unlimited-disable": "off",
+    },
+  },
+  {
+    files: ["**/routes/**/*.{ts,tsx}"],
+    rules: {
+      "react-refresh/only-export-components": "off",
+    },
+  },
+  ...pluginQuery.configs["flat/recommended"],
+  ...pluginRouter.configs["flat/recommended"],
+);

--- a/apps/accounts/tsconfig.json
+++ b/apps/accounts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["vite/client"]
+  },
+  "extends": [
+    "@tsconfig/node-lts/tsconfig.json",
+    "@tsconfig/node-ts/tsconfig.json",
+    "@tsconfig/strictest/tsconfig.json"
+  ],
+  "include": ["**/*.ts", "**/*.tsx", "vite.config.ts"]
+}

--- a/apps/accounts/vite.config.ts
+++ b/apps/accounts/vite.config.ts
@@ -1,0 +1,14 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    cloudflare({ viteEnvironment: { name: "ssr" } }),
+    tailwindcss(),
+    tanstackStart(),
+    react(),
+  ],
+});

--- a/apps/accounts/vitest.config.ts
+++ b/apps/accounts/vitest.config.ts
@@ -1,0 +1,14 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+  plugins: [
+    cloudflareTest({
+      remoteBindings: false,
+      wrangler: { configPath: "./wrangler.jsonc" },
+    }),
+  ],
+});

--- a/apps/accounts/wrangler.jsonc
+++ b/apps/accounts/wrangler.jsonc
@@ -1,0 +1,31 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "accounts",
+  "compatibility_date": "2025-12-25",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "@tanstack/react-start/server-entry",
+  "routes": [
+    {
+      "pattern": "accounts.shikanime.studio",
+      "custom_domain": true,
+      "zone_name": "shikanime.studio",
+    },
+  ],
+  "observability": {
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": true,
+    },
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "accounts",
+      "database_id": "PLACEHOLDER_SET_AFTER_TOFU_APPLY",
+    },
+  ],
+  "placement": { "mode": "smart" },
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* __->__ #308
* #307
* #306

Wire the accounts app to the TanStack Start Vite plugin, a Cloudflare Worker
serving accounts.shikanime.studio (custom domain), a D1 binding named DB
(database_id left as a placeholder until OpenTofu provisions it), and the
Workers-pool Vitest config for the auth handler tests.

Design: .hermes/plans/2026-08-09_043459-accounts-central-idp.md (Task 3)
Related: accounts central IdP initiative