### PR TITLE
Add accounts Drizzle schema for auth + OIDC provider

### DIFF
--- a/apps/accounts/drizzle.config.ts
+++ b/apps/accounts/drizzle.config.ts
@@ -1,0 +1,68 @@
+import type { Config } from "drizzle-kit";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { defineConfig } from "drizzle-kit";
+import { z } from "zod";
+
+const config = {
+  out: "./migrations",
+  dialect: "sqlite",
+} satisfies Config;
+
+function createLocalConfig() {
+  const wranglerDir = path.join(
+    process.cwd(),
+    ".wrangler/state/v3/d1/miniflare-D1DatabaseObject",
+  );
+  const sqliteFile = fs
+    .readdirSync(wranglerDir)
+    .find((file) => file.endsWith(".sqlite"));
+  if (!sqliteFile) {
+    throw new Error(
+      "No SQLite file found in .wrangler/state/v3/d1/miniflare-D1DatabaseObject",
+    );
+  }
+  return {
+    ...config,
+    schema: "./src/schema.ts",
+    dbCredentials: {
+      url: path.join(wranglerDir, sqliteFile),
+    },
+  } satisfies Config;
+}
+
+const remoteEnvSchema = z.object({
+  CLOUDFLARE_ACCOUNT_ID: z.string().min(1),
+  CLOUDFLARE_DATABASE_ID: z.string().min(1),
+  CLOUDFLARE_API_TOKEN: z.string().min(1),
+});
+
+function createRemoteConfig() {
+  const env = remoteEnvSchema.parse(process.env);
+  return {
+    ...config,
+    schema: "./src/schema.ts",
+    driver: "d1-http",
+    dbCredentials: {
+      accountId: env.CLOUDFLARE_ACCOUNT_ID,
+      databaseId: env.CLOUDFLARE_DATABASE_ID,
+      token: env.CLOUDFLARE_API_TOKEN,
+    },
+  } satisfies Config;
+}
+
+const envFlags = z
+  .object({
+    LOCAL: z.string().optional(),
+    REMOTE: z.string().optional(),
+  })
+  .parse(process.env);
+
+export default defineConfig(
+  envFlags.LOCAL !== "true"
+    ? createLocalConfig()
+    : envFlags.REMOTE !== "true"
+      ? createRemoteConfig()
+      : createLocalConfig(),
+);

--- a/apps/accounts/src/schema.ts
+++ b/apps/accounts/src/schema.ts
@@ -1,0 +1,172 @@
+import { sql } from "drizzle-orm";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: integer("email_verified", { mode: "boolean" }).notNull(),
+  image: text("image"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+export const sessions = sqliteTable("session", {
+  id: text("id").primaryKey(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+});
+
+export const accounts = sqliteTable("account", {
+  id: text("id").primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: integer("access_token_expires_at", {
+    mode: "timestamp",
+  }),
+  refreshTokenExpiresAt: integer("refresh_token_expires_at", {
+    mode: "timestamp",
+  }),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+export const verifications = sqliteTable("verification", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+export const rateLimits = sqliteTable("rate_limits", {
+  id: text("id").primaryKey(),
+  key: text("key"),
+  count: integer("count"),
+  lastRequest: integer("last_request", { mode: "number" }),
+});
+
+export const jwkss = sqliteTable("jwks", {
+  id: text("id").primaryKey(),
+  publicKey: text("public_key").notNull(),
+  privateKey: text("private_key").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }),
+});
+
+export const oauthClients = sqliteTable("oauth_client", {
+  id: text("id").primaryKey(),
+  clientId: text("client_id").notNull().unique(),
+  clientSecret: text("client_secret"),
+  disabled: integer("disabled", { mode: "boolean" }).default(false),
+  skipConsent: integer("skip_consent", { mode: "boolean" }).default(false),
+  enableEndSession: integer("enable_end_session", { mode: "boolean" }),
+  subjectType: text("subject_type"),
+  scopes: text("scopes", { mode: "json" }).$type<Array<string>>(),
+  userId: text("user_id").references(() => users.id),
+  referenceId: text("reference_id"),
+  name: text("name"),
+  uri: text("uri"),
+  icon: text("icon"),
+  contacts: text("contacts", { mode: "json" }).$type<Array<string>>(),
+  tos: text("tos"),
+  policy: text("policy"),
+  softwareId: text("software_id"),
+  softwareVersion: text("software_version"),
+  softwareStatement: text("software_statement"),
+  redirectUris: text("redirect_uris", { mode: "json" })
+    .notNull()
+    .$type<Array<string>>()
+    .default(sql`'[]'`),
+  postLogoutRedirectUris: text("post_logout_redirect_uris", {
+    mode: "json",
+  }).$type<Array<string>>(),
+  tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
+  grantTypes: text("grant_types", { mode: "json" }).$type<Array<string>>(),
+  responseTypes: text("response_types", { mode: "json" }).$type<
+    Array<string>
+  >(),
+  public: integer("public", { mode: "boolean" }),
+  type: text("type"),
+  requirePKCE: integer("require_pkce", { mode: "boolean" }),
+  metadata: text("metadata", { mode: "json" }),
+  createdAt: integer("created_at", { mode: "timestamp" }),
+  updatedAt: integer("updated_at", { mode: "timestamp" }),
+});
+
+export const oauthAccessTokens = sqliteTable("oauth_access_token", {
+  id: text("id").primaryKey(),
+  token: text("token").notNull().unique(),
+  clientId: text("client_id").notNull(),
+  sessionId: text("session_id"),
+  refreshId: text("refresh_id"),
+  userId: text("user_id").references(() => users.id),
+  referenceId: text("reference_id"),
+  scopes: text("scopes", { mode: "json" })
+    .notNull()
+    .$type<Array<string>>()
+    .default(sql`'[]'`),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+});
+
+export const oauthRefreshTokens = sqliteTable("oauth_refresh_token", {
+  id: text("id").primaryKey(),
+  token: text("token").notNull().unique(),
+  clientId: text("client_id").notNull(),
+  sessionId: text("session_id"),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+  referenceId: text("reference_id"),
+  scopes: text("scopes", { mode: "json" })
+    .notNull()
+    .$type<Array<string>>()
+    .default(sql`'[]'`),
+  revoked: integer("revoked", { mode: "timestamp" }),
+  authTime: integer("auth_time", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+});
+
+export const oauthConsents = sqliteTable("oauth_consent", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").references(() => users.id),
+  clientId: text("client_id").notNull(),
+  referenceId: text("reference_id"),
+  scopes: text("scopes", { mode: "json" })
+    .notNull()
+    .$type<Array<string>>()
+    .default(sql`'[]'`),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+export interface Schema extends Record<string, unknown> {
+  users: typeof users;
+  sessions: typeof sessions;
+  accounts: typeof accounts;
+  verifications: typeof verifications;
+  rateLimits: typeof rateLimits;
+  jwkss: typeof jwkss;
+  oauthClients: typeof oauthClients;
+  oauthAccessTokens: typeof oauthAccessTokens;
+  oauthRefreshTokens: typeof oauthRefreshTokens;
+  oauthConsents: typeof oauthConsents;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* __->__ #309
* #308
* #307
* #306

Define the accounts app's Drizzle schema: better-auth core tables (user,
session, account, verification, rate_limits), the jwt plugin jwks table,
and the oauthProvider plugin tables (oauth_client, oauth_access_token,
oauth_refresh_token, oauth_consent).

Columns were reconciled against better-auth's own getAuthTables() output
for v1.6.26 (unique token columns, nullable oauth_consent.userId, jwks
expiresAt) rather than hand-copied, so they match the adapter contract.

Design: .hermes/plans/2026-08-09_043459-accounts-central-idp.md (Task 4)
Related: accounts central IdP initiative