### PR TITLE
Add accounts sign-in and consent pages

### DIFF
--- a/apps/accounts/src/lib/auth-client.ts
+++ b/apps/accounts/src/lib/auth-client.ts
@@ -1,0 +1,10 @@
+import { oauthProviderClient } from "@better-auth/oauth-provider/client";
+import { createAuthClient } from "better-auth/client";
+import { oneTapClient } from "better-auth/client/plugins";
+
+export const authClient = createAuthClient({
+  plugins: [
+    oneTapClient({ clientId: import.meta.env.VITE_GOOGLE_CLIENT_ID }),
+    oauthProviderClient(),
+  ],
+});

--- a/apps/accounts/src/routeTree.gen.ts
+++ b/apps/accounts/src/routeTree.gen.ts
@@ -9,9 +9,21 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SignInRouteImport } from './routes/sign-in'
+import { Route as ConsentRouteImport } from './routes/consent'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 
+const SignInRoute = SignInRouteImport.update({
+  id: '/sign-in',
+  path: '/sign-in',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConsentRoute = ConsentRouteImport.update({
+  id: '/consent',
+  path: '/consent',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -25,32 +37,54 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/consent': typeof ConsentRoute
+  '/sign-in': typeof SignInRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/consent': typeof ConsentRoute
+  '/sign-in': typeof SignInRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/consent': typeof ConsentRoute
+  '/sign-in': typeof SignInRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/api/auth/$'
+  fullPaths: '/' | '/consent' | '/sign-in' | '/api/auth/$'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/api/auth/$'
-  id: '__root__' | '/' | '/api/auth/$'
+  to: '/' | '/consent' | '/sign-in' | '/api/auth/$'
+  id: '__root__' | '/' | '/consent' | '/sign-in' | '/api/auth/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ConsentRoute: typeof ConsentRoute
+  SignInRoute: typeof SignInRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sign-in': {
+      id: '/sign-in'
+      path: '/sign-in'
+      fullPath: '/sign-in'
+      preLoaderRoute: typeof SignInRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/consent': {
+      id: '/consent'
+      path: '/consent'
+      fullPath: '/consent'
+      preLoaderRoute: typeof ConsentRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -70,6 +104,8 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ConsentRoute: ConsentRoute,
+  SignInRoute: SignInRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/accounts/src/routes/consent.tsx
+++ b/apps/accounts/src/routes/consent.tsx
@@ -1,0 +1,150 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { authClient } from "../lib/auth-client";
+
+export const Route = createFileRoute("/consent")({
+  component: Consent,
+});
+
+function readAuthorizationQuery() {
+  const search = typeof window === "undefined" ? "" : window.location.search;
+  const params = new URLSearchParams(search);
+  const scope = params.get("scope");
+  return {
+    clientId: params.get("client_id"),
+    scopes: scope ? scope.split(" ").filter(Boolean) : [],
+  };
+}
+
+function Consent() {
+  const [{ clientId, scopes }] = useState(readAuthorizationQuery);
+  const [resolvedName, setResolvedName] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(clientId !== null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(
+    clientId === null ? "Missing client_id in the authorization request." : null,
+  );
+
+  const clientName = resolvedName ?? clientId;
+
+  useEffect(() => {
+    if (clientId === null) {
+      return;
+    }
+
+    authClient.oauth2
+      .publicClient({ query: { client_id: clientId } })
+      .then((res) => {
+        if (res.data) {
+          setResolvedName(res.data.client_name ?? res.data.client_id);
+        }
+      })
+      .catch(() => {
+        // Fall back to showing the raw client_id.
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [clientId]);
+
+  const submitConsent = (accept: boolean) => {
+    setIsSubmitting(true);
+    setError(null);
+    authClient.oauth2
+      .consent({ accept })
+      .then((res) => {
+        if (res.error) {
+          setError(res.error.message ?? "Unable to complete the request.");
+          setIsSubmitting(false);
+          return;
+        }
+        if (res.data?.url) {
+          window.location.href = res.data.url;
+          return;
+        }
+        setIsSubmitting(false);
+      })
+      .catch(() => {
+        setError("Unable to complete the request.");
+        setIsSubmitting(false);
+      });
+  };
+
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center p-4">
+      <div className="card bg-base-100 w-full max-w-md shadow-xl">
+        <div className="card-body gap-6">
+          <div className="text-center">
+            <h1 className="card-title justify-center text-xl font-bold">
+              Authorize access
+            </h1>
+            <p className="mt-2 text-sm opacity-70">
+              {isLoading
+                ? "Loading application details…"
+                : (
+                    <>
+                      <span className="font-semibold">
+                        {clientName ?? "An application"}
+                      </span>
+                      {" "}
+                      wants to access your Shikanime Studio account.
+                    </>
+                  )}
+            </p>
+          </div>
+
+          {scopes.length > 0 && (
+            <div>
+              <h2 className="mb-2 text-sm font-semibold opacity-80">
+                This will allow it to:
+              </h2>
+              <ul className="list-inside list-disc space-y-1 text-sm opacity-80">
+                {scopes.map(scope => (
+                  <li key={scope}>{scope}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {error && (
+            <div role="alert" className="alert alert-error text-sm">
+              <span>{error}</span>
+            </div>
+          )}
+
+          <div className="card-actions justify-end gap-2">
+            <button
+              type="button"
+              className="btn btn-ghost rounded-full"
+              onClick={() => {
+                submitConsent(false);
+              }}
+              disabled={isSubmitting}
+            >
+              DENY
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary rounded-full font-bold"
+              onClick={() => {
+                submitConsent(true);
+              }}
+              disabled={isSubmitting}
+            >
+              {isSubmitting
+                ? (
+                    <>
+                      <span className="loading loading-spinner loading-xs"></span>
+                      WORKING
+                    </>
+                  )
+                : (
+                    "ALLOW"
+                  )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/accounts/src/routes/sign-in.tsx
+++ b/apps/accounts/src/routes/sign-in.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { authClient } from "../lib/auth-client";
+
+export const Route = createFileRoute("/sign-in")({
+  component: SignIn,
+});
+
+function SignIn() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignIn = () => {
+    setIsLoading(true);
+    setError(null);
+    authClient.signIn
+      .social({
+        provider: "google",
+        callbackURL: "/",
+      })
+      .catch(() => {
+        setError("An error occurred during sign in");
+        setIsLoading(false);
+      });
+  };
+
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center p-4">
+      <div className="card bg-base-100 w-full max-w-sm shadow-xl">
+        <div className="card-body items-center gap-6 text-center">
+          <h1 className="card-title text-xl font-bold">
+            Sign in to Shikanime Studio
+          </h1>
+          <p className="text-sm opacity-70">
+            Use your Google account to continue.
+          </p>
+          <button
+            type="button"
+            className="btn btn-primary w-full rounded-full font-bold"
+            onClick={handleSignIn}
+            disabled={isLoading}
+          >
+            {isLoading
+              ? (
+                  <>
+                    <span className="loading loading-spinner loading-xs"></span>
+                    SIGNING IN
+                  </>
+                )
+              : (
+                  "CONTINUE WITH GOOGLE"
+                )}
+          </button>
+          <p className="text-xs opacity-50">
+            One Tap may appear automatically. Or use the button above.
+          </p>
+          {error && (
+            <div role="alert" className="alert alert-error text-sm">
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* __->__ #312
* #311
* #310
* #309
* #308
* #307
* #306

Build the user-facing OAuth surfaces for the identity provider. /sign-in
renders the Google social sign-in (better-auth oneTap client) and /consent
renders the OAuth approval screen, reading the pending request from the
authorization query and calling authClient.oauth2.consent({ accept }).

The client wrapper uses the real @better-auth/oauth-provider/client export
(oauthProviderClient) — not the oauthClient name in the draft plan. The
regenerated routeTree.gen.ts now includes both routes.

Design: .hermes/plans/2026-08-09_043459-accounts-central-idp.md (Task 7)
Related: accounts central IdP initiative