### PR TITLE
Add accounts D1 database to infrastructure

### DIFF
--- a/infra/output.tf
+++ b/infra/output.tf
@@ -6,3 +6,12 @@ output "reiya" {
   }
   description = "Reiya D1 databases"
 }
+
+output "accounts" {
+  value = {
+    d1_databases = {
+      database_id = cloudflare_d1_database.default["accounts"].id
+    }
+  }
+  description = "Accounts IdP D1 databases"
+}

--- a/infra/variable.tf
+++ b/infra/variable.tf
@@ -46,6 +46,7 @@ variable "d1s" {
   type        = map(string)
   description = "Map of Cloudflare D1 databases"
   default = {
-    reiya = "reiya"
+    accounts = "accounts"
+    reiya    = "reiya"
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* __->__ #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Register the accounts identity provider's D1 database in the OpenTofu
config: add "accounts" to the d1s map (provisioned via the existing
cloudflare_d1_database.default for_each) and expose it through a new
"accounts" output mirroring the reiya one.

DNS for accounts.shikanime.studio is intentionally NOT added here: the
Worker declares routes with custom_domain: true, so Cloudflare provisions
the custom domain record automatically on deploy.

Manual follow-ups (not performed by this commit):
- tofu apply to create the D1 database
- wrangler deploy / versions upload to mint the worker id and write the
  real database_id into apps/accounts/wrangler.jsonc (PLACEHOLDER)
- wrangler secret put for BETTER_AUTH_SECRET, GOOGLE_*, REIYA_CLIENT_SECRET

Design: .hermes/plans/2026-08-09_043459-accounts-central-idp.md (Task 9)
Related: accounts central IdP initiative