### PR TITLE
Configure reiya as a generic OAuth client of accounts

### DIFF
--- a/apps/reiya/src/env.d.ts
+++ b/apps/reiya/src/env.d.ts
@@ -4,6 +4,7 @@ declare namespace Cloudflare {
   interface Env {
     BETTER_AUTH_SECRET: string;
     GOOGLE_CLIENT_SECRET: string;
+    REIYA_CLIENT_SECRET: string;
   }
 }
 

--- a/apps/reiya/src/lib/auth-client.ts
+++ b/apps/reiya/src/lib/auth-client.ts
@@ -1,8 +1,9 @@
 import { createAuthClient } from "better-auth/client";
-import { oneTapClient } from "better-auth/client/plugins";
+import { genericOAuthClient, oneTapClient } from "better-auth/client/plugins";
 
 export const authClient = createAuthClient({
   plugins: [
     oneTapClient({ clientId: import.meta.env.PUBLIC_GOOGLE_CLIENT_ID }),
+    genericOAuthClient(),
   ],
 });

--- a/apps/reiya/src/lib/auth.ts
+++ b/apps/reiya/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { oneTap } from "better-auth/plugins";
+import { genericOAuth, oneTap } from "better-auth/plugins";
 import { env } from "cloudflare:workers";
 import * as schema from "../schema";
 
@@ -15,7 +15,27 @@ export function createAuth(db: DrizzleD1Database<typeof schema>) {
       },
       usePlural: true,
     }),
-    plugins: [oneTap()],
+    plugins: [
+      oneTap(),
+      genericOAuth({
+        config: [
+          {
+            providerId: "accounts",
+            clientId: "reiya",
+            clientSecret: env.REIYA_CLIENT_SECRET,
+            scopes: ["openid", "profile", "email", "offline_access"],
+            redirectURI:
+              "https://reiya.shikanime.studio/api/auth/oauth2/callback/accounts",
+            authorizationUrl:
+              "https://accounts.shikanime.studio/api/auth/oauth2/authorize",
+            tokenUrl: "https://accounts.shikanime.studio/api/auth/oauth2/token",
+            userInfoUrl:
+              "https://accounts.shikanime.studio/api/auth/oauth2/userinfo",
+            issuer: "https://accounts.shikanime.studio/api/auth",
+          },
+        ],
+      }),
+    ],
     secret: env.BETTER_AUTH_SECRET,
     baseURL: import.meta.env.SITE,
     socialProviders: {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* __->__ #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Add the genericOAuth plugin to reiya's better-auth server config so reiya
can sign in through the accounts identity provider as the reiya client
(providerId accounts, the shared scopes, and the accounts oauth2
callback URI). The client auth factory gains genericOAuthClient() to drive
the flow in the browser.

The better-auth genericOAuth config uses authorizationUrl / tokenUrl /
userInfoUrl + issuer (there is no discoveryConfig / *Endpoint shape), and
the client plugin takes no config. REIYA_CLIENT_SECRET is referenced from
Cloudflare.Env and added to reiya's env.d.ts; the secret itself is set via
wrangler in a later manual step (Task 12).

oneTap() and the Google social provider are retained — accounts remains
one of several sign-in paths.

Design: .hermes/plans/2026-08-09_043459-accounts-central-idp.md (Task 10)
Related: accounts central IdP initiative