### PR TITLE
Swap reiya login button to sign in via accounts

### DIFF
--- a/apps/reiya/src/components/LoginButton.tsx
+++ b/apps/reiya/src/components/LoginButton.tsx
@@ -11,8 +11,8 @@ export default function LoginButton() {
   const handleSignIn = () => {
     setIsLoading(true);
     authClient.signIn
-      .social({
-        provider: "google",
+      .oauth2({
+        providerId: "accounts",
         callbackURL: "/",
       })
       .catch(() => {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* __->__ #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Point the reiya LoginButton at the accounts identity provider through the
genericOAuth flow (authClient.signIn.oauth2({ providerId: "accounts" }))
instead of Google social directly. The callback lands back on reiya's root
and the accounts oauth2 callback route completes the exchange.

BaseLayout's Google One Tap is intentionally left as-is: better-auth's
oneTap client is Google-GSI-only (no genericOAuth provider targeting), so
it remains a separate direct Google sign-in path.

Design: .hermes/plans/2026-08-09_043459-accounts-central-idp.md (Task 11)
Related: accounts central IdP initiative