### PR TITLE
Document manual secret + infra steps for accounts IdP

### DIFF
--- a/.hermes/accounts-idp-manual-steps.md
+++ b/.hermes/accounts-idp-manual-steps.md
@@ -1,0 +1,67 @@
+# accounts Central IdP — Manual Deployment Steps
+
+This runbook covers the steps that cannot be performed by the agent because
+they require live Cloudflare access and secret values. Each step is manual and
+must be run by a human with the appropriate credentials.
+
+The corresponding implementation commits live on the `accounts-idp` branch.
+
+## Task 9 — Infrastructure (OpenTofu)
+
+Apply the D1 database for accounts:
+
+```sh
+cd infra
+tofu init      # if not already initialized
+tofu plan
+tofu apply     # creates the "accounts" D1 database
+```
+
+DNS for `accounts.shikanime.studio` is NOT managed here: the accounts Worker
+declares `routes` with `custom_domain: true`, so Cloudflare provisions the
+custom-domain record automatically on first deploy.
+
+## Task 9 — Worker id + database_id (wrangler)
+
+The accounts `wrangler.jsonc` ships with a `"PLACEHOLDER"` `database_id`. After
+`tofu apply` returns the real D1 id, either:
+
+- run `wrangler deploy` / `wrangler versions upload` for accounts (it writes
+  the real id into `wrangler.jsonc` automatically), or
+- manually replace `PLACEHOLDER` with the id from `tofu output accounts`.
+
+## Task 12 — reiya Worker secret rotation (manual wrangler)
+
+accounts registers reiya as a trusted OAuth client with
+`clientSecret: env.REIYA_CLIENT_SECRET`. The SAME secret string must be set on
+both workers (accounts already references `REIYA_CLIENT_SECRET` in its
+`trustedClients`; reiya references it in its `genericOAuth` client config).
+
+Generate one shared secret value, then set it on both workers:
+
+```sh
+# one value, set on BOTH workers (they must match)
+wrangler secret put REIYA_CLIENT_SECRET \
+  --config apps/accounts/wrangler.jsonc
+wrangler secret put REIYA_CLIENT_SECRET \
+  --config apps/reiya/wrangler.jsonc
+```
+
+Also confirm the other accounts secrets are set (they were referenced in
+`apps/accounts/wrangler.jsonc` vars as test placeholders and must be real in
+production):
+
+```sh
+wrangler secret put BETTER_AUTH_SECRET      --config apps/accounts/wrangler.jsonc
+wrangler secret put GOOGLE_CLIENT_ID        --config apps/accounts/wrangler.jsonc
+wrangler secret put GOOGLE_CLIENT_SECRET     --config apps/accounts/wrangler.jsonc
+```
+
+## Verification after secrets are set
+
+- `pnpm -F @shikanime-studio/accounts deploy` (or `wrangler deploy`) succeeds.
+- Visiting reiya's sign-in button redirects to
+  `https://accounts.shikanime.studio/api/auth/oauth2/authorize?...`.
+- Completing the accounts flow returns to
+  `https://reiya.shikanime.studio/api/auth/oauth2/callback/accounts` with a
+  code that exchanges successfully (no `invalid_client` / `invalid_secret`).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* __->__ #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Task 12 is manual: the agent cannot run tofu apply or wrangler secret put
(live Cloudflare access + secret values required, and secrets must never be
hardcoded). This runbook captures the exact commands the operator runs:

- tofu apply to create the accounts D1 database (Task 9 infra).
- wrangler to mint the accounts worker id + real database_id (Task 9).
- wrangler secret put REIYA_CLIENT_SECRET on BOTH accounts and reiya workers
  (the shared OAuth client secret must match on each side), plus the other
  accounts production secrets (Task 12).

Also backfills the .hermes/ design reference cited in earlier commit
messages for this branch.

Design: .hermes/accounts-idp-manual-steps.md (Task 12)
Related: accounts central IdP initiative