### PR TITLE
Add packages/auth-shared workspace package skeleton

### DIFF
--- a/packages/auth-shared/package.json
+++ b/packages/auth-shared/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shikanime-studio/auth-shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "better-auth": "catalog:runtime"
+  },
+  "devDependencies": {
+    "@antfu/eslint-config": "catalog:lint",
+    "@tsconfig/node-lts": "catalog:types",
+    "@tsconfig/node-ts": "catalog:types",
+    "@tsconfig/strictest": "catalog:types",
+    "@tsconfig/vite-react": "catalog:types",
+    "@types/node": "catalog:types",
+    "eslint": "catalog:lint",
+    "typescript": "catalog:types",
+    "vitest": "catalog:test"
+  },
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=10"
+  }
+}

--- a/packages/auth-shared/src/index.ts
+++ b/packages/auth-shared/src/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared auth helpers for the shikanime.studio identity mesh.
+ *
+ * The accounts app is the central OAuth/OIDC identity provider. It sets a
+ * cross-subdomain session cookie (see `SESSION_COOKIE_NAME`) on
+ * `.shikanime.studio`, which the other apps (fade, www, links, reiya) read to
+ * discover the signed-in user without a per-app session.
+ *
+ * This package currently exposes the cookie contract and a low-level
+ * extractor. The session reader that decodes/verifies the token lives in
+ * `./session` (added in a later commit).
+ */
+
+/** Cookie name better-auth writes for the active session. */
+export const SESSION_COOKIE_NAME = "better-auth.session_token";
+
+/**
+ * Read the raw session token from a request's cookies, if present.
+ *
+ * Returns `null` when the cookie is absent. Does NOT verify the token — use
+ * the session reader for that.
+ */
+export function getSessionToken(
+  request: Request | Headers | Record<string, string | undefined>,
+): string | null {
+  let cookieHeader: string | null = null;
+
+  if (request instanceof Request) {
+    cookieHeader = request.headers.get("cookie");
+  }
+  else if (request instanceof Headers) {
+    cookieHeader = request.get("cookie");
+  }
+  else {
+    cookieHeader = request["cookie"] ?? null;
+  }
+
+  if (!cookieHeader) {
+    return null;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rest] = part.trim().split("=");
+    if (rawName === SESSION_COOKIE_NAME) {
+      return decodeURIComponent(rest.join("="));
+    }
+  }
+
+  return null;
+}

--- a/packages/auth-shared/tsconfig.build.json
+++ b/packages/auth-shared/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/auth-shared/tsconfig.json
+++ b/packages/auth-shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "extends": [
+    "@tsconfig/node-lts/tsconfig.json",
+    "@tsconfig/node-ts/tsconfig.json",
+    "@tsconfig/vite-react/tsconfig.json",
+    "@tsconfig/strictest/tsconfig.json"
+  ],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -905,6 +905,40 @@ importers:
         specifier: catalog:infra
         version: 4.84.1
 
+  packages/auth-shared:
+    dependencies:
+      better-auth:
+        specifier: catalog:runtime
+        version: 1.6.26(af55388e90e231ea65b8f50c04f7b23a)
+    devDependencies:
+      '@antfu/eslint-config':
+        specifier: catalog:lint
+        version: 7.7.3(@eslint-react/eslint-plugin@2.13.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/rule-tester@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(astro-eslint-parser@1.3.0)(eslint-plugin-astro@1.7.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-format@2.0.1(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier-plugin-astro@0.14.1)(typescript@5.9.3)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@tsconfig/node-lts':
+        specifier: catalog:types
+        version: 24.0.0
+      '@tsconfig/node-ts':
+        specifier: catalog:types
+        version: 23.6.4
+      '@tsconfig/strictest':
+        specifier: catalog:types
+        version: 2.0.8
+      '@tsconfig/vite-react':
+        specifier: catalog:types
+        version: 7.0.2
+      '@types/node':
+        specifier: catalog:types
+        version: 22.19.17
+      eslint:
+        specifier: catalog:lint
+        version: 9.39.4(jiti@2.6.1)
+      typescript:
+        specifier: catalog:types
+        version: 5.9.3
+      vitest:
+        specifier: catalog:test
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(jsdom@27.4.0(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+
 packages:
 
   '@acemir/cssom@0.9.31':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - apps/cfproxy
   - apps/www
   - apps/accounts
+  - packages/auth-shared
 catalogs:
   build:
     "@astrojs/cloudflare": ^13.2.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* #320
* __->__ #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Scaffold the shared auth library that the consuming apps (fade, www, links,
reiya) use to read the accounts IdP's cross-subdomain session cookie. This
commit is the package skeleton only:

- package.json with the @shikanime-studio/* name scheme, better-auth from
  the runtime catalog, and build/lint/test scripts.
- tsconfig.json (+ tsconfig.build.json emitting declarations to dist/).
- src/index.ts exposing SESSION_COOKIE_NAME and a getSessionToken()
  extractor (reads the raw token from a Request / Headers / cookie record).
  No verification yet — the decoding/verifying reader lands in a later commit.

Registered packages/auth-shared in pnpm-workspace.yaml; pnpm install keeps
the lockfile consistent. tsc --noEmit and the declaration build both pass.

Design: .hermes/accounts-idp-manual-steps.md (Task 14)
Related: accounts central IdP initiative