### PR TITLE
Add shared session reader to auth-shared

### DIFF
--- a/packages/auth-shared/src/index.ts
+++ b/packages/auth-shared/src/index.ts
@@ -11,6 +11,8 @@
  * `./session` (added in a later commit).
  */
 
+export { getSession, type GetSessionOptions, type SessionResult } from "./session";
+
 /** Cookie name better-auth writes for the active session. */
 export const SESSION_COOKIE_NAME = "better-auth.session_token";
 

--- a/packages/auth-shared/src/session.ts
+++ b/packages/auth-shared/src/session.ts
@@ -1,0 +1,89 @@
+import type { Session, User } from "better-auth/types";
+import { getSessionToken, SESSION_COOKIE_NAME } from "./index";
+
+/**
+ * Options for {@link getSession}.
+ */
+export interface GetSessionOptions {
+  /**
+   * Base URL of the accounts identity provider. Defaults to the production
+   * deployment; override in tests or for staging.
+   */
+  baseURL?: string;
+  /**
+   * Abort the upstream get-session call after this many milliseconds.
+   * Defaults to 2500ms to keep edge rendering snappy.
+   */
+  timeoutMs?: number;
+  /**
+   * Fetch implementation override (mainly for tests / non-Worker runtimes).
+   * Defaults to the global `fetch`.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+export interface SessionResult {
+  session: Session;
+  user: User;
+}
+
+const DEFAULT_BASE_URL = "https://accounts.shikanime.studio";
+const DEFAULT_TIMEOUT_MS = 2500;
+
+/**
+ * Resolve the signed-in user from the accounts IdP's cross-subdomain session
+ * cookie.
+ *
+ * The session cookie is an opaque better-auth token, so it cannot be decoded
+ * locally — we forward it to the IdP's `get-session` endpoint, which is the
+ * same mechanism the better-auth client SDK uses. The consuming app reads the
+ * cookie off its own `.shikanime.studio` request (the browser sends it because
+ * the cookie is scoped to the parent domain) and proxies it upstream.
+ *
+ * Returns `null` when there is no session cookie or the IdP cannot confirm a
+ * live session (expired, revoked, network error, non-2xx). Callers should
+ * treat `null` as "anonymous" and never throw.
+ */
+export async function getSession(
+  request: Request | Headers,
+  options: GetSessionOptions = {},
+): Promise<SessionResult | null> {
+  const token = getSessionToken(request);
+  if (!token) {
+    return null;
+  }
+
+  const baseURL = options.baseURL ?? DEFAULT_BASE_URL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetchImpl(`${baseURL}/api/auth/get-session`, {
+      headers: {
+        // Forward only the session cookie; nothing else is needed upstream.
+        cookie: `${SESSION_COOKIE_NAME}=${token}`,
+      },
+      // better-auth returns 200 + the session, or 200 + null when anonymous.
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      return null;
+    }
+
+    const body = (await res.json()) as SessionResult | null;
+    return body;
+  }
+  catch {
+    // Network failure, timeout (AbortError), or malformed response — treat as
+    // no session rather than breaking the page render.
+    return null;
+  }
+  finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* #322
* #321
* __->__ #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Implement getSession() in the auth-shared package: it extracts the accounts
IdP's cross-subdomain session cookie (via getSessionToken) and forwards it to
the IdP's /api/auth/get-session endpoint to resolve the live Session/User.

The session cookie is an opaque better-auth token (the jwt() plugin only
issues a separate OIDC id_token), so local decoding is not possible — proxying
to the IdP is the same mechanism the better-auth client SDK uses and keeps a
single source of truth. The reader is intentionally resilient: it returns null
(no throw) on missing cookie, network error, timeout, or non-2xx, so callers
treat null as anonymous.

- configurable baseURL (default https://accounts.shikanime.studio), timeout
  (default 2500ms), and fetch implementation (for tests/non-Worker runtimes).
- typed return (Session, User from better-auth/types), re-exported from the
  package root alongside SESSION_COOKIE_NAME / getSessionToken.

tsc --noEmit and the declaration build both pass.

Design: .hermes/accounts-idp-manual-steps.md (Task 15)
Related: accounts central IdP initiative