### PR TITLE
Consume accounts session in fade via auth-shared

### DIFF
--- a/apps/fade/package.json
+++ b/apps/fade/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "catalog:build",
+    "@shikanime-studio/auth-shared": "workspace:*",
     "@tailwindcss/vite": "catalog:build",
     "@tanstack/react-db": "catalog:runtime",
     "@tanstack/react-devtools": "catalog:runtime",

--- a/apps/fade/src/lib/session.ts
+++ b/apps/fade/src/lib/session.ts
@@ -1,0 +1,21 @@
+import type { SessionResult } from "@shikanime-studio/auth-shared";
+import { getSession } from "@shikanime-studio/auth-shared";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+
+/** Base URL of the accounts identity provider that owns the shared session. */
+const ACCOUNTS_BASE_URL = "https://accounts.shikanime.studio";
+
+/**
+ * Resolve the signed-in user from the accounts IdP.
+ *
+ * Runs server-side only: the cross-subdomain `better-auth.session_token`
+ * cookie is scoped to `.shikanime.studio`, so the browser sends it with the
+ * document request and we forward it upstream from the worker. Returns `null`
+ * for anonymous visitors — never throws.
+ */
+export const getSessionUser = createServerFn({ method: "GET" }).handler(
+  async (): Promise<SessionResult | null> => {
+    return await getSession(getRequest(), { baseURL: ACCOUNTS_BASE_URL });
+  },
+);

--- a/apps/fade/src/routes/__root.tsx
+++ b/apps/fade/src/routes/__root.tsx
@@ -11,11 +11,17 @@ import {
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { MixpanelProvider } from "../components/MixpanelProvider";
 import { ThemeProvider } from "../components/ThemeProvider";
+import { getSessionUser } from "../lib/session";
 import appCss from "../styles.css?url";
 
 const queryClient = new QueryClient();
 
 export const Route = createRootRoute({
+  // Resolves the accounts IdP session during SSR and exposes it to every route
+  // via router context (`Route.useRouteContext().session`). `null` = anonymous.
+  beforeLoad: async () => {
+    return { session: await getSessionUser() };
+  },
   head: () => ({
     meta: [
       {

--- a/packages/auth-shared/package.json
+++ b/packages/auth-shared/package.json
@@ -3,6 +3,14 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,6 +438,9 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: catalog:build
         version: 1.33.1(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260421.1)(wrangler@4.84.1)
+      '@shikanime-studio/auth-shared':
+        specifier: workspace:*
+        version: link:../../packages/auth-shared
       '@tailwindcss/vite':
         specifier: catalog:build
         version: 4.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* #323
* __->__ #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Make the fade TanStack Start app read the accounts IdP's cross-subdomain
session so the signed-in user is available app-wide.

- apps/fade/src/lib/session.ts: a server-only createServerFn getSessionUser()
  that pulls the incoming Request via getRequest() from
  @tanstack/react-start/server (the 1.167 replacement for the removed
  getWebRequest) and forwards it to auth-shared's getSession() pointed at
  https://accounts.shikanime.studio. Returns null for anonymous, never throws.
- apps/fade/src/routes/__root.tsx: beforeLoad calls getSessionUser() and
  returns { session }, so it resolves server-side during SSR and any route can
  read it via useRouteContext(). No auth UI added — read-only consumption.
- apps/fade/package.json: adds @shikanime-studio/auth-shared as workspace:*.

Prerequisite fix: packages/auth-shared had no main/types/exports, so the bare
specifier was unresolvable (every consumer would have hit this). Added an
exports map pointing at src/index.ts so workspace consumers import TS source
directly — no per-app tsconfig paths / vite alias workaround needed.

Verified: fade tsc --noEmit and vite build both exit 0; auth-shared tsc still
clean. Confirmed the session call stays in the server bundle only.

Design: .hermes/accounts-idp-manual-steps.md (Task 17)
Related: accounts central IdP initiative