### PR TITLE
Consume accounts session in www via auth-shared

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -21,6 +21,7 @@
     "@astrojs/cloudflare": "catalog:build",
     "@astrojs/sitemap": "catalog:runtime",
     "@fontsource-variable/inter": "catalog:runtime",
+    "@shikanime-studio/auth-shared": "workspace:*",
     "@tailwindcss/vite": "catalog:build",
     "astro": "catalog:build",
     "daisyui": "catalog:runtime",

--- a/apps/www/src/env.d.ts
+++ b/apps/www/src/env.d.ts
@@ -5,3 +5,13 @@ interface ImportMetaEnv {
   readonly PUBLIC_MIXPANEL_TOKEN: string;
   readonly PUBLIC_MIXPANEL_API_HOST?: string;
 }
+
+declare namespace App {
+  interface Locals {
+    /**
+     * Session resolved from the accounts IdP by `src/middleware.ts`.
+     * `null` for anonymous visitors (or when the IdP could not be reached).
+     */
+    user?: import("@shikanime-studio/auth-shared").SessionResult | null;
+  }
+}

--- a/apps/www/src/layouts/BaseLayout.astro
+++ b/apps/www/src/layouts/BaseLayout.astro
@@ -11,9 +11,15 @@ const {
   title = 'Shikanime Studio',
   description = 'Where ideas collide and imagination soars, we are proud dreamers on the mission to make them a reality',
 } = Astro.props
+
+/**
+ * Session resolved by `src/middleware.ts` from the accounts IdP.
+ * Read-only: exposed for downstream personalisation, no auth UI here.
+ */
+const user = Astro.locals.user?.user ?? null
 ---
 
-<html lang="en">
+<html lang="en" data-authenticated={user ? 'true' : 'false'}>
   <head>
     <meta charset="utf-8" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/apps/www/src/middleware.ts
+++ b/apps/www/src/middleware.ts
@@ -1,0 +1,22 @@
+import { getSession } from "@shikanime-studio/auth-shared";
+import { defineMiddleware } from "astro:middleware";
+
+/** Base URL of the accounts identity provider that owns the shared session. */
+const ACCOUNTS_BASE_URL = "https://accounts.shikanime.studio";
+
+/**
+ * Resolve the signed-in user for every request and expose it on `locals`.
+ *
+ * The cross-subdomain `better-auth.session_token` cookie is scoped to
+ * `.shikanime.studio`, so the browser sends it with the document request and
+ * the worker forwards it to the accounts IdP. `getSession` never throws:
+ * anonymous visitors, expired tokens, and upstream failures all resolve to
+ * `null`, so rendering is never blocked.
+ */
+export const onRequest = defineMiddleware(async (context, next) => {
+  context.locals.user = await getSession(context.request, {
+    baseURL: ACCOUNTS_BASE_URL,
+  });
+
+  return next();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,6 +613,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: catalog:runtime
         version: 5.2.8
+      '@shikanime-studio/auth-shared':
+        specifier: workspace:*
+        version: link:../../packages/auth-shared
       '@tailwindcss/vite':
         specifier: catalog:build
         version: 4.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -846,6 +849,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: catalog:runtime
         version: 5.2.8
+      '@shikanime-studio/auth-shared':
+        specifier: workspace:*
+        version: link:../../packages/auth-shared
       '@tailwindcss/vite':
         specifier: catalog:build
         version: 4.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* #324
* __->__ #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Make the www Astro app read the accounts IdP's cross-subdomain session.

- apps/www/src/middleware.ts: onRequest calls getSession(context.request,
  { baseURL: https://accounts.shikanime.studio }) and stores the result on
  context.locals.user (SessionResult | null). Never blocks rendering — null
  for anonymous / expired / upstream failure.
- apps/www/src/env.d.ts: augment App.Locals with
  user?: import('@shikanime-studio/auth-shared').SessionResult | null.
- apps/www/src/layouts/BaseLayout.astro: reads Astro.locals.user and surfaces
  it read-only (data-authenticated); no auth UI added.
- apps/www/package.json: adds @shikanime-studio/auth-shared as workspace:*.

auth-shared now has a proper exports map (fixed in the fade commit), so the
bare specifier resolves with no per-app tsconfig/vite workaround.

Verified: pnpm -F @shikanime-studio/www check (astro check) and build both
exit 0.

Design: .hermes/accounts-idp-manual-steps.md (Task 18)
Related: accounts central IdP initiative