### PR TITLE
Consume accounts session in links via auth-shared

### DIFF
--- a/apps/links/package.json
+++ b/apps/links/package.json
@@ -21,6 +21,7 @@
     "@astrojs/cloudflare": "catalog:build",
     "@astrojs/sitemap": "catalog:runtime",
     "@fontsource-variable/inter": "catalog:runtime",
+    "@shikanime-studio/auth-shared": "workspace:*",
     "@tailwindcss/vite": "catalog:build",
     "astro": "catalog:build",
     "daisyui": "catalog:runtime",

--- a/apps/links/src/env.d.ts
+++ b/apps/links/src/env.d.ts
@@ -5,3 +5,13 @@ interface ImportMetaEnv {
   readonly PUBLIC_MIXPANEL_TOKEN: string;
   readonly PUBLIC_MIXPANEL_API_HOST?: string;
 }
+
+declare namespace App {
+  interface Locals {
+    /**
+     * Session resolved from the accounts IdP by `src/middleware.ts`.
+     * `null` for anonymous visitors (or when the IdP could not be reached).
+     */
+    user?: import("@shikanime-studio/auth-shared").SessionResult | null;
+  }
+}

--- a/apps/links/src/layouts/BaseLayout.astro
+++ b/apps/links/src/layouts/BaseLayout.astro
@@ -8,9 +8,15 @@ interface Props {
 }
 
 const { title, description } = Astro.props
+
+/**
+ * Session resolved by `src/middleware.ts` from the accounts IdP.
+ * Read-only: exposed for downstream personalisation, no auth UI here.
+ */
+const user = Astro.locals.user?.user ?? null
 ---
 
-<html lang="en">
+<html lang="en" data-authenticated={user ? 'true' : 'false'}>
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/apps/links/src/middleware.ts
+++ b/apps/links/src/middleware.ts
@@ -1,0 +1,22 @@
+import { getSession } from "@shikanime-studio/auth-shared";
+import { defineMiddleware } from "astro:middleware";
+
+/** Base URL of the accounts identity provider that owns the shared session. */
+const ACCOUNTS_BASE_URL = "https://accounts.shikanime.studio";
+
+/**
+ * Resolve the signed-in user for every request and expose it on `locals`.
+ *
+ * The cross-subdomain `better-auth.session_token` cookie is scoped to
+ * `.shikanime.studio`, so the browser sends it with the document request and
+ * the worker forwards it to the accounts IdP. `getSession` never throws:
+ * anonymous visitors, expired tokens, and upstream failures all resolve to
+ * `null`, so rendering is never blocked.
+ */
+export const onRequest = defineMiddleware(async (context, next) => {
+  context.locals.user = await getSession(context.request, {
+    baseURL: ACCOUNTS_BASE_URL,
+  });
+
+  return next();
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* #326
* #325
* __->__ #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

Make the links Astro app read the accounts IdP's cross-subdomain session.

- apps/links/src/middleware.ts: onRequest calls getSession(context.request,
  { baseURL: https://accounts.shikanime.studio }) and stores the result on
  context.locals.user (SessionResult | null). Never blocks rendering.
- apps/links/src/env.d.ts: augment App.Locals with
  user?: import('@shikanime-studio/auth-shared').SessionResult | null.
- Entry point surfaces the user read-only (data-authenticated); no auth UI.

Note: subagent also verified getSession against the live accounts.shikanime.studio
IdP (no-cookie and bogus-cookie both return null gracefully).

Verified: pnpm -F @shikanime-studio/links check (astro check) and build both
exit 0.

Design: .hermes/accounts-idp-manual-steps.md (Task 19)
Related: accounts central IdP initiative