### PR TITLE
Document accounts CI coverage (Task 21)

### DIFF
--- a/.hermes/accounts-idp-manual-steps.md
+++ b/.hermes/accounts-idp-manual-steps.md
@@ -65,3 +65,30 @@ wrangler secret put GOOGLE_CLIENT_SECRET     --config apps/accounts/wrangler.jso
 - Completing the accounts flow returns to
   `https://reiya.shikanime.studio/api/auth/oauth2/callback/accounts` with a
   code that exchanges successfully (no `invalid_client` / `invalid_secret`).
+
+## Task 21 — CI coverage (no code change required)
+
+accounts is automatically covered by the existing integration pipeline:
+
+- `.github/workflows/integration.yaml` → `javascript.yaml` runs the
+  `shikanime-studio/actions/pnpm/integration@v9` composite action, which
+  executes the per-app `types` / `test` / `build` pnpm scripts across the
+  workspace.
+- accounts is already a registered workspace member (`pnpm-workspace.yaml`,
+  added in the scaffold commit) and ships the standard scripts the action
+  invokes: `types` (`wrangler types`), `test` (`vitest run`), `build`
+  (`vite build`).
+- No per-app CI enumeration (matrix/list) exists, so there is nothing to edit
+  to opt accounts in — workspace discovery handles it.
+
+Verified locally that all three gates pass for accounts:
+
+```
+pnpm -F @shikanime-studio/accounts types   # exit 0
+pnpm -F @shikanime-studio/accounts test    # 3 passed
+pnpm -F @shikanime-studio/accounts build   # exit 0
+```
+
+The only CI-relevant manual prerequisite is Task 9 (the D1 database must exist
+for `test`/`build` to resolve the `env.DB` binding) and Task 12 (secrets must
+be set for a real deploy). Neither requires a CI config change.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #327
* __->__ #326
* #325
* #324
* #323
* #322
* #321
* #320
* #319
* #318
* #317
* #316
* #315
* #314
* #313
* #312
* #311
* #310
* #309
* #308
* #307
* #306

accounts is auto-discovered by the generic integration pipeline
(.github/workflows/integration.yaml -> javascript.yaml ->
shikanime-studio/actions/pnpm/integration@v9), which runs the per-app types /
test / build pnpm scripts across the workspace. Because accounts is a
registered workspace member (pnpm-workspace.yaml) and ships those three
standard scripts, no CI config edit is required to opt it in.

Recorded in .hermes/accounts-idp-manual-steps.md with the local verification
that all three gates pass (types exit 0, test 3 passed, build exit 0). The
only manual CI prerequisites are Task 9 (D1 database must exist) and Task 12
(secrets must be set) — neither needs a config change.

Design: .hermes/accounts-idp-manual-steps.md (Task 21)
Related: accounts central IdP initiative